### PR TITLE
Correct naming of the getter method

### DIFF
--- a/src/Singleton.java
+++ b/src/Singleton.java
@@ -9,7 +9,7 @@ public class Singleton {
     // the attributes of your singleton class
     private int content = 1337;
 
-    public static Singleton getSingleton() {
+    public static Singleton getInstance() {
         if(singleton == null)
             singleton = new Singleton();
 


### PR DESCRIPTION
Renamed getSingleton() to getInstance() based on the Singleton Pattern convention